### PR TITLE
Enhancements for modeling complex primitives

### DIFF
--- a/v2x/vlog_to_pbtype.py
+++ b/v2x/vlog_to_pbtype.py
@@ -933,9 +933,6 @@ def make_leaf_pb(outfile, yj, mod, mod_pname, pb_type_xml):
                         port, iodir)
                 attrs["max"] = splitspec[1]
             else:
-                assert iodir == "input", \
-                    "Only input ports can have {} timing definition."
-                "Port {}, direction {}.".format(xmltype, port, iodir)
                 attrs["value"] = splitspec[1]
             ET.SubElement(xml_parent, xmltype, attrs)
 


### PR DESCRIPTION
This PR enhances V2X so it now can be used to model a "Sequential block (with internal paths)" primitive according to https://docs.verilogtorouting.org/en/latest/tutorials/arch/timing_modeling/#sequential-block-with-internal-paths

The change will be required by the upcoming fixes to the `LOGIC` cell model that will allow to pack `mux8x0` efficiently