### PR TITLE
Relaxed restriction for uppercase BLIF model names

### DIFF
--- a/v2x/vlog_to_model.py
+++ b/v2x/vlog_to_model.py
@@ -173,8 +173,6 @@ def vlog_to_model(infiles, includes, top, outfile=None):
     else:
         # Is a leaf model
         topname = tmod.attr("MODEL_NAME", top)
-        assert topname == topname.upper(
-        ), "Leaf model names should be all uppercase!"
         modclass = tmod.attr("CLASS", "")
 
         if modclass not in ("input", "output", "lut", "routing", "flipflop"):

--- a/v2x/vlog_to_pbtype.py
+++ b/v2x/vlog_to_pbtype.py
@@ -1011,8 +1011,6 @@ def make_pb_type(
 
     # Process type and class of module
     model_name = mod.attr("MODEL_NAME", mod.name)
-    assert model_name == model_name.upper(
-    ), "Model name should be uppercase. {}".format(model_name)
     mod_cls = mod.CLASS
     if mod_cls is not None:
         if mod_cls == "input":


### PR DESCRIPTION
This PR removes assertion for upper case BLIF model names.