### PR TITLE
FASM LUT support

### DIFF
--- a/tests/fasm_lut/lut_cell/lut_cell.model.xml
+++ b/tests/fasm_lut/lut_cell/lut_cell.model.xml
@@ -1,0 +1,3 @@
+<models xmlns:xi="http://www.w3.org/2001/XInclude">
+  <!--this file is intentionally left blank-->
+</models>

--- a/tests/fasm_lut/lut_cell/lut_cell.pb_type.xml
+++ b/tests/fasm_lut/lut_cell/lut_cell.pb_type.xml
@@ -1,0 +1,7 @@
+<?xml version='1.0' encoding='utf-8'?>
+<pb_type xmlns:xi="http://www.w3.org/2001/XInclude" name="LUT_CELL" num_pb="1">
+  <blif_model>.names</blif_model>
+  <pb_class>lut</pb_class>
+  <input name="I" num_pins="4" port_class="lut_in"/>
+  <output name="O" num_pins="1" port_class="lut_out"/>
+</pb_type>

--- a/tests/fasm_lut/lut_cell/lut_cell.sim.v
+++ b/tests/fasm_lut/lut_cell/lut_cell.sim.v
@@ -1,0 +1,14 @@
+(* CLASS="lut" *)
+(* whitebox *)
+module LUT_CELL (I, O);
+
+    (* PORT_CLASS="lut_in" *)
+    input  wire [3:0] I;
+
+    (* PORT_CLASS="lut_out" *)
+    output wire       O;
+
+    parameter [15:0] INIT = 16'b0;
+    assign O = INIT[I];
+
+endmodule

--- a/tests/fasm_lut/single/golden.pb_type.xml
+++ b/tests/fasm_lut/single/golden.pb_type.xml
@@ -1,0 +1,35 @@
+<?xml version='1.0' encoding='utf-8'?>
+<pb_type xmlns:xi="http://www.w3.org/2001/XInclude" name="SINGLE" num_pb="1">
+  <input name="I" num_pins="4"/>
+  <output name="O" num_pins="1"/>
+  <pb_type name="lut" num_pb="1">
+    <!--old_name LUT_CELL-->
+    <xi:include href="../lut_cell/lut_cell.pb_type.xml" xpointer="xpointer(pb_type/child::node()[local-name()!='metadata'])"/>
+  </pb_type>
+  <interconnect>
+    <direct>
+      <port name="I[0]" type="input"/>
+      <port from="lut" name="I[0]" type="output"/>
+    </direct>
+    <direct>
+      <port name="I[1]" type="input"/>
+      <port from="lut" name="I[1]" type="output"/>
+    </direct>
+    <direct>
+      <port name="I[2]" type="input"/>
+      <port from="lut" name="I[2]" type="output"/>
+    </direct>
+    <direct>
+      <port name="I[3]" type="input"/>
+      <port from="lut" name="I[3]" type="output"/>
+    </direct>
+    <direct>
+      <port from="lut" name="O" type="input"/>
+      <port name="O" type="output"/>
+    </direct>
+  </interconnect>
+  <metadata>
+    <meta name="fasm_type">LUT</meta>
+    <meta name="fasm_lut">LUT_INIT[15:0] = lut</meta>
+  </metadata>
+</pb_type>

--- a/tests/fasm_lut/single/single.sim.v
+++ b/tests/fasm_lut/single/single.sim.v
@@ -1,0 +1,21 @@
+`include "../lut_cell/lut_cell.sim.v"
+
+(* FASM_LUT="LUT_INIT" *)
+module SINGLE(
+    input  wire [3:0] I,
+    output wire       O
+);
+
+    parameter [15:0] INIT = 16'd0;
+
+    // The LUT
+    LUT_CELL # (
+        .INIT (INIT),
+    )
+    lut
+    (
+        .I (I),
+        .O (O)
+    );
+
+endmodule

--- a/tests/fasm_lut/split/golden.pb_type.xml
+++ b/tests/fasm_lut/split/golden.pb_type.xml
@@ -1,0 +1,56 @@
+<?xml version='1.0' encoding='utf-8'?>
+<pb_type xmlns:xi="http://www.w3.org/2001/XInclude" name="SPLIT" num_pb="1">
+  <input name="I" num_pins="4"/>
+  <output name="O" num_pins="2"/>
+  <pb_type name="lut" num_pb="2">
+    <!--old_name LUT_CELL old_num_pb 1-->
+    <xi:include href="../lut_cell/lut_cell.pb_type.xml" xpointer="xpointer(pb_type/child::node()[local-name()!='metadata'])"/>
+  </pb_type>
+  <interconnect>
+    <direct>
+      <port name="I[0]" type="input"/>
+      <port from="lut[0]" name="I[0]" type="output"/>
+    </direct>
+    <direct>
+      <port name="I[0]" type="input"/>
+      <port from="lut[1]" name="I[0]" type="output"/>
+    </direct>
+    <direct>
+      <port name="I[1]" type="input"/>
+      <port from="lut[0]" name="I[1]" type="output"/>
+    </direct>
+    <direct>
+      <port name="I[1]" type="input"/>
+      <port from="lut[1]" name="I[1]" type="output"/>
+    </direct>
+    <direct>
+      <port name="I[2]" type="input"/>
+      <port from="lut[0]" name="I[2]" type="output"/>
+    </direct>
+    <direct>
+      <port name="I[2]" type="input"/>
+      <port from="lut[1]" name="I[2]" type="output"/>
+    </direct>
+    <direct>
+      <port name="I[3]" type="input"/>
+      <port from="lut[0]" name="I[3]" type="output"/>
+    </direct>
+    <direct>
+      <port name="I[3]" type="input"/>
+      <port from="lut[1]" name="I[3]" type="output"/>
+    </direct>
+    <direct>
+      <port from="lut[0]" name="O" type="input"/>
+      <port name="O[0]" type="output"/>
+    </direct>
+    <direct>
+      <port from="lut[1]" name="O" type="input"/>
+      <port name="O[1]" type="output"/>
+    </direct>
+  </interconnect>
+  <metadata>
+    <meta name="fasm_type">SPLIT_LUT</meta>
+    <meta name="fasm_lut">INIT[15:0] = lut[0]
+INIT[31:16] = lut[1]</meta>
+  </metadata>
+</pb_type>

--- a/tests/fasm_lut/split/split.sim.v
+++ b/tests/fasm_lut/split/split.sim.v
@@ -1,0 +1,20 @@
+`include "../lut_cell/lut_cell.sim.v"
+
+(* FASM_LUT *)
+module SPLIT(
+    input  wire [3:0] I,
+    output wire [1:0] O
+);
+
+    genvar i;
+    generate for (i=0; i<2; i=i+1) begin
+
+        // Lut fraction
+        LUT_CELL lut (
+            .I (I),
+            .O (O[i])
+        );
+
+    end endgenerate
+
+endmodule


### PR DESCRIPTION
This PR adds support for "FASM LUT" annotation. This allows FASM feature emission for LUTs modeled as `.names` primitives.