### PR TITLE
Fixed for routing muxes

### DIFF
--- a/tests/fasm_mux/gate/gate.model.xml
+++ b/tests/fasm_mux/gate/gate.model.xml
@@ -1,0 +1,11 @@
+<models xmlns:xi="http://www.w3.org/2001/XInclude">
+  <model name="GATE">
+    <input_ports>
+      <port name="I0"/>
+      <port name="I1"/>
+    </input_ports>
+    <output_ports>
+      <port name="O"/>
+    </output_ports>
+  </model>
+</models>

--- a/tests/fasm_mux/gate/gate.pb_type.xml
+++ b/tests/fasm_mux/gate/gate.pb_type.xml
@@ -1,0 +1,7 @@
+<?xml version='1.0' encoding='utf-8'?>
+<pb_type xmlns:xi="http://www.w3.org/2001/XInclude" name="GATE" num_pb="1">
+  <blif_model>.subckt GATE</blif_model>
+  <input name="I0" num_pins="1"/>
+  <input name="I1" num_pins="1"/>
+  <output name="O" num_pins="1"/>
+</pb_type>

--- a/tests/fasm_mux/gate/gate.sim.v
+++ b/tests/fasm_mux/gate/gate.sim.v
@@ -1,0 +1,8 @@
+(* blackbox *)
+module GATE(
+  input  wire I0,
+  input  wire I1,
+  output wire O
+);
+
+endmodule

--- a/tests/fasm_mux/golden.model.xml
+++ b/tests/fasm_mux/golden.model.xml
@@ -1,0 +1,4 @@
+<models xmlns:xi="http://www.w3.org/2001/XInclude">
+  <xi:include href="gate/gate.model.xml" xpointer="xpointer(models/child::node())"/>
+  <xi:include href="mux/mux.model.xml" xpointer="xpointer(models/child::node())"/>
+</models>

--- a/tests/fasm_mux/golden.pb_type.xml
+++ b/tests/fasm_mux/golden.pb_type.xml
@@ -1,0 +1,60 @@
+<?xml version='1.0' encoding='utf-8'?>
+<pb_type xmlns:xi="http://www.w3.org/2001/XInclude" num_pb="1" name="PARENT">
+  <input name="I" num_pins="4"/>
+  <output name="O" num_pins="2"/>
+  <pb_type name="gate_a" num_pb="1">
+    <!--old_name GATE-->
+    <xi:include href="gate/gate.pb_type.xml" xpointer="xpointer(pb_type/child::node()[local-name()!='metadata'])"/>
+    <metadata>
+      <meta name="fasm_prefix">GATE</meta>
+    </metadata>
+  </pb_type>
+  <pb_type name="gate_b" num_pb="1">
+    <!--old_name GATE-->
+    <xi:include href="gate/gate.pb_type.xml" xpointer="xpointer(pb_type/child::node()[local-name()!='metadata'])"/>
+  </pb_type>
+  <interconnect>
+    <direct>
+      <port name="I[0]" type="input"/>
+      <port name="I0" type="output" from="gate_a"/>
+    </direct>
+    <direct>
+      <port name="I[1]" type="input"/>
+      <port name="I1" type="output" from="gate_a"/>
+    </direct>
+    <direct>
+      <port name="I[2]" type="input"/>
+      <port name="I0" type="output" from="gate_b"/>
+    </direct>
+    <direct>
+      <port name="I[3]" type="input"/>
+      <port name="I1" type="output" from="gate_b"/>
+    </direct>
+    <mux name="mux_with_fasm">
+      <port name="I[0]" type="input">
+        <metadata>
+          <meta name="fasm_mux">I0</meta>
+        </metadata>
+      </port>
+      <port name="O" type="input" from="gate_a">
+        <metadata>
+          <meta name="fasm_mux">I1</meta>
+        </metadata>
+      </port>
+      <port name="O[0]" type="output"/>
+      <metadata>
+        <meta name="type">bel</meta>
+        <meta name="subtype">routing</meta>
+      </metadata>
+    </mux>
+    <mux name="mux_without_fasm">
+      <port name="I[2]" type="input"/>
+      <port name="O" type="input" from="gate_b"/>
+      <port name="O[1]" type="output"/>
+      <metadata>
+        <meta name="type">bel</meta>
+        <meta name="subtype">routing</meta>
+      </metadata>
+    </mux>
+  </interconnect>
+</pb_type>

--- a/tests/fasm_mux/mux/mux.model.xml
+++ b/tests/fasm_mux/mux/mux.model.xml
@@ -1,0 +1,2 @@
+<models xmlns:xi="http://www.w3.org/2001/XInclude">
+</models>

--- a/tests/fasm_mux/mux/mux.sim.v
+++ b/tests/fasm_mux/mux/mux.sim.v
@@ -1,0 +1,19 @@
+(* CLASS="routing" *)
+(* MODES="I0;I1" *)
+(* whitebox *)
+
+module MUX (
+    input  wire I0,
+    input  wire I1,
+    output wire O
+);
+
+    parameter MODE = "";
+
+    generate if (MODE == "I0") begin
+        assign O = I0;
+    end else if (MODE == "I1") begin
+        assign O = I1;
+    end endgenerate
+
+endmodule

--- a/tests/fasm_mux/parent.sim.v
+++ b/tests/fasm_mux/parent.sim.v
@@ -1,0 +1,40 @@
+`include "./gate/gate.sim.v"
+`include "./mux/mux.sim.v"
+
+module PARENT (
+    input  wire [3:0] I,
+    output wire [1:0] O
+);
+
+    // A gate that can be bypassed by a mux with FASM annotation
+    wire a;
+
+    (* FASM_PREFIX="GATE" *)    
+    GATE gate_a (
+        .I0 (I[0]),
+        .I1 (I[1]),
+        .O  (a)
+    );
+
+    (* FASM *)
+    MUX mux_with_fasm (
+        .I0 (I[0]),
+        .I1 (a),
+        .O  (O[0])
+    );
+
+    // A gate that can be bypassed by a mux without FASM annotation
+    wire b;
+    GATE gate_b (
+        .I0 (I[2]),
+        .I1 (I[3]),
+        .O  (b)
+    );
+
+    MUX mux_without_fasm (
+        .I0 (I[2]),
+        .I1 (b),
+        .O  (O[1])
+    );
+
+endmodule

--- a/tests/mux_pack_pattern/clb.sim.v
+++ b/tests/mux_pack_pattern/clb.sim.v
@@ -1,0 +1,46 @@
+`include "./lut/lut4.sim.v"
+`include "./ff/ff.sim.v"
+`include "./mux/mux.sim.v"
+
+module CLB (
+    input  wire CLK,
+    input  wire [3:0] IA,
+    input  wire [3:0] IB,
+    output wire O
+);
+
+    // "A" LUT
+    (* PACK="ALUT_TO_FF" *)
+    wire oa;
+
+    LUT4 ALUT (
+        .I(IA),
+        .O(oa)
+    );
+
+    // "B" LUT
+    (* PACK="BLUT_TO_FF" *)
+    wire ob;
+
+    LUT4 BLUT (
+        .I(IB),
+        .O(ob)
+    );
+
+    // Routing mux
+    wire d;
+
+    MUX LUT_MUX (
+        .I0 (oa),
+        .I1 (ob),
+        .O  (d)
+    );
+
+    // Flip-flop
+    FF FF (
+        .CLK (CLK),
+        .D   (d),
+        .Q   (O)
+    );
+
+endmodule

--- a/tests/mux_pack_pattern/ff/ff.model.xml
+++ b/tests/mux_pack_pattern/ff/ff.model.xml
@@ -1,0 +1,12 @@
+<models xmlns:xi="http://www.w3.org/2001/XInclude">
+  <!-- https://docs.verilogtorouting.org/en/latest/tutorials/arch/timing_modeling/#sequential-block-no-internal-paths -->
+  <model name="FF">
+    <input_ports>
+      <port name="CLK" is_clock="1"/>
+      <port name="D" clock="CLK"/>
+    </input_ports>
+    <output_ports>
+      <port name="Q" clock="CLK"/>
+    </output_ports>
+  </model>
+</models>

--- a/tests/mux_pack_pattern/ff/ff.pb_type.xml
+++ b/tests/mux_pack_pattern/ff/ff.pb_type.xml
@@ -1,0 +1,10 @@
+<?xml version='1.0' encoding='utf-8'?>
+<pb_type xmlns:xi="http://www.w3.org/2001/XInclude" num_pb="1" name="FF">
+  <blif_model>.subckt FF</blif_model>
+  <clock name="CLK" num_pins="1"/>
+  <input name="D" num_pins="1"/>
+  <output name="Q" num_pins="1"/>
+  <T_setup port="D" clock="CLK" value="10e-12"/>
+  <T_hold port="D" clock="CLK" value="10e-12"/>
+  <T_clock_to_Q port="Q" clock="CLK" max="10e-12"/>
+</pb_type>

--- a/tests/mux_pack_pattern/ff/ff.sim.v
+++ b/tests/mux_pack_pattern/ff/ff.sim.v
@@ -1,0 +1,17 @@
+(* whitebox *)
+module FF (CLK, D, Q);
+
+	input wire CLK;
+
+	(* SETUP="CLK 10e-12" *)
+	(* HOLD="CLK 10e-12" *)
+	input wire D;
+
+	(* CLK_TO_Q="CLK 10e-12" *)
+	output reg Q;
+	(* ASSOC_CLOCK="CLK" *)
+
+	always @ ( posedge CLK ) begin
+		Q <= D;
+	end
+endmodule

--- a/tests/mux_pack_pattern/golden.model.xml
+++ b/tests/mux_pack_pattern/golden.model.xml
@@ -1,0 +1,5 @@
+<models xmlns:xi="http://www.w3.org/2001/XInclude">
+  <xi:include href="ff/ff.model.xml" xpointer="xpointer(models/child::node())"/>
+  <xi:include href="lut/lut4.model.xml" xpointer="xpointer(models/child::node())"/>
+  <xi:include href="mux/mux.model.xml" xpointer="xpointer(models/child::node())"/>
+</models>

--- a/tests/mux_pack_pattern/golden.pb_type.xml
+++ b/tests/mux_pack_pattern/golden.pb_type.xml
@@ -1,0 +1,75 @@
+<?xml version='1.0' encoding='utf-8'?>
+<pb_type xmlns:xi="http://www.w3.org/2001/XInclude" num_pb="1" name="CLB">
+  <clock name="CLK" num_pins="1"/>
+  <input name="IA" num_pins="4"/>
+  <input name="IB" num_pins="4"/>
+  <output name="O" num_pins="1"/>
+  <pb_type name="ALUT" num_pb="1">
+    <!--old_name LUT4-->
+    <xi:include href="lut/lut4.pb_type.xml" xpointer="xpointer(pb_type/child::node()[local-name()!='metadata'])"/>
+  </pb_type>
+  <pb_type name="BLUT" num_pb="1">
+    <!--old_name LUT4-->
+    <xi:include href="lut/lut4.pb_type.xml" xpointer="xpointer(pb_type/child::node()[local-name()!='metadata'])"/>
+  </pb_type>
+  <xi:include href="ff/ff.pb_type.xml"/>
+  <interconnect>
+    <direct>
+      <port name="IA[0]" type="input"/>
+      <port name="I[0]" type="output" from="ALUT"/>
+    </direct>
+    <direct>
+      <port name="IA[1]" type="input"/>
+      <port name="I[1]" type="output" from="ALUT"/>
+    </direct>
+    <direct>
+      <port name="IA[2]" type="input"/>
+      <port name="I[2]" type="output" from="ALUT"/>
+    </direct>
+    <direct>
+      <port name="IA[3]" type="input"/>
+      <port name="I[3]" type="output" from="ALUT"/>
+    </direct>
+    <direct>
+      <port name="IB[0]" type="input"/>
+      <port name="I[0]" type="output" from="BLUT"/>
+    </direct>
+    <direct>
+      <port name="IB[1]" type="input"/>
+      <port name="I[1]" type="output" from="BLUT"/>
+    </direct>
+    <direct>
+      <port name="IB[2]" type="input"/>
+      <port name="I[2]" type="output" from="BLUT"/>
+    </direct>
+    <direct>
+      <port name="IB[3]" type="input"/>
+      <port name="I[3]" type="output" from="BLUT"/>
+    </direct>
+    <direct>
+      <port name="CLK" type="input"/>
+      <port name="CLK" type="output" from="FF"/>
+    </direct>
+    <direct>
+      <port name="Q" type="input" from="FF"/>
+      <port name="O" type="output"/>
+    </direct>
+    <mux name="LUT_MUX">
+      <port name="O" type="input" from="ALUT"/>
+      <port name="O" type="input" from="BLUT"/>
+      <port name="D" type="output" from="FF"/>
+      <pack_pattern name="ALUT_TO_FF" type="pack">
+        <port name="O" type="input" from="ALUT"/>
+        <port name="D" type="output" from="FF"/>
+      </pack_pattern>
+      <pack_pattern name="BLUT_TO_FF" type="pack">
+        <port name="O" type="input" from="BLUT"/>
+        <port name="D" type="output" from="FF"/>
+      </pack_pattern>
+      <metadata>
+        <meta name="type">bel</meta>
+        <meta name="subtype">routing</meta>
+      </metadata>
+    </mux>
+  </interconnect>
+</pb_type>

--- a/tests/mux_pack_pattern/lut/lut4.model.xml
+++ b/tests/mux_pack_pattern/lut/lut4.model.xml
@@ -1,0 +1,10 @@
+<models xmlns:xi="http://www.w3.org/2001/XInclude">
+  <model name="LUT4">
+    <input_ports>
+      <port combinational_sink_ports="O" name="I"/>
+    </input_ports>
+    <output_ports>
+      <port name="O"/>
+    </output_ports>
+  </model>
+</models>

--- a/tests/mux_pack_pattern/lut/lut4.pb_type.xml
+++ b/tests/mux_pack_pattern/lut/lut4.pb_type.xml
@@ -1,0 +1,9 @@
+<?xml version='1.0' encoding='utf-8'?>
+<pb_type xmlns:xi="http://www.w3.org/2001/XInclude" name="LUT4" num_pb="1">
+  <blif_model>.subckt LUT4</blif_model>
+  <input name="I" num_pins="4"/>
+  <output name="O" num_pins="1"/>
+  <delay_matrix in_port="LUT4.I" out_port="LUT4.O" type="max">
+30e-12 20e-12 11e-12 3e-12
+</delay_matrix>
+</pb_type>

--- a/tests/mux_pack_pattern/lut/lut4.sim.v
+++ b/tests/mux_pack_pattern/lut/lut4.sim.v
@@ -1,0 +1,9 @@
+(* whitebox *)
+module LUT4 (I, O);
+	input wire [3:0] I;
+	(* DELAY_MATRIX_I="30e-12 20e-12 11e-12 3e-12" *)
+	output wire O;
+
+	localparam INIT = 16'h0000;
+	assign O = INIT[I];
+endmodule

--- a/tests/mux_pack_pattern/mux/mux.model.xml
+++ b/tests/mux_pack_pattern/mux/mux.model.xml
@@ -1,0 +1,2 @@
+<models xmlns:xi="http://www.w3.org/2001/XInclude">
+</models>

--- a/tests/mux_pack_pattern/mux/mux.sim.v
+++ b/tests/mux_pack_pattern/mux/mux.sim.v
@@ -1,0 +1,19 @@
+(* CLASS="routing" *)
+(* MODES="I0;I1" *)
+(* whitebox *)
+
+module MUX (
+    input  wire I0,
+    input  wire I1,
+    output wire O
+);
+
+    parameter MODE = "";
+
+    generate if (MODE == "I0") begin
+        assign O = I0;
+    end else if (MODE == "I1") begin
+        assign O = I1;
+    end endgenerate
+
+endmodule

--- a/tests/muxes/use_mux.sim.v
+++ b/tests/muxes/use_mux.sim.v
@@ -15,8 +15,10 @@ module USE_MUX (a, b, c, o1, o2);
 	LOGICBOX lboxc (.I(c), .O(logic_c));
 
 	parameter FASM_MUX1 = "I0";
+    (* FASM *)
 	RMUX #(.MODE(FASM_MUX1)) mux1 (.I0(logic_a), .I1(logic_b), .O(o1));
 
 	parameter FASM_MUX2 = "I0";
+    (* FASM *)
 	RMUX #(.MODE(FASM_MUX2)) mux2 (.I0(logic_a), .I1(logic_c), .O(o2));
 endmodule

--- a/tests/vtr/lutff-pair/pair.sim.v
+++ b/tests/vtr/lutff-pair/pair.sim.v
@@ -21,6 +21,7 @@ module PAIR (
 	DFF ff (.CLK(CLK), .D(lut_out), .Q(ff_out));
 
 	parameter FF_BYPASS = "F";
+    (* FASM *)
 	OMUX #(.MODE(FF_BYPASS)) mux(.L(lut_out), .F(ff_out), .O(O));
 
 endmodule

--- a/v2x/vlog_to_pbtype.py
+++ b/v2x/vlog_to_pbtype.py
@@ -330,8 +330,12 @@ def metadata_for_fasm_lut(yj, parent, children):
 
     # "fasm_lut" metadata
     feature = parent.attr("FASM_LUT")
-    if not feature or isinstance(feature, int):
+    try:
+        # Use "INIT" FASM feature if the attribute is set to an integer.
+        feature = int(feature)
         feature = "INIT"
+    except ValueError:
+        pass
 
     # Single LUT
     if len(children_data) == 1:


### PR DESCRIPTION
This PR fixes two important things which are necessary for supporting carry-chains in AP3 architecture:
- Optional FASM annotation. Now the `(* FASM *)` attribute needs to be placed on the routing mux cell instance for FASM metadata to be attached.
- Pack patterns for routing muxes. Now pack patterns specified on input nets of a routing mux are incorporated into it as well.

CI tests are included.